### PR TITLE
Multi user support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ USER 1000:1000
 EXPOSE 5000
 
 # Run with aggressive worker recycling
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--worker-class", "gevent", "--workers", "2", "--timeout", "60", "app:app"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--worker-class", "gevent", "--workers", "1", "--timeout", "60", "app:app"]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Follow the [Streamrip configuration guide](https://github.com/nathom/streamrip/w
 ### Option 1: Pre-built workflow. 
 1: Add this to your `docker-compose.yml`
 
-```
+```yaml
   streamrip:
     image: anoddname/streamrip-web-gui:latest 
     container_name: streamrip-web
@@ -60,6 +60,7 @@ Follow the [Streamrip configuration guide](https://github.com/nathom/streamrip/w
       - STREAMRIP_CONFIG=/config/streamrip/config.toml
       - DOWNLOAD_DIR=/music
       - MAX_CONCURRENT_DOWNLOADS=1
+      # - STREAMRIP_USERS=user1,user2,user3 # optional: a list of users to separate downloads by user (e.g. DOWNLOAD_DIR/user1/)
     volumes:
       - /home/YOURUSERNAME/.config/streamrip:/config/streamrip:rw
       - /home/YOURUSERNAME/media-server/data/Music:/music:rw
@@ -93,6 +94,7 @@ services:
           - STREAMRIP_CONFIG=/config/streamrip/config.toml
           - DOWNLOAD_DIR=/music
           - MAX_CONCURRENT_DOWNLOADS=2
+          # - STREAMRIP_USERS=user1,user2,user3 # optional: a list of users to separate downloads by user (e.g. DOWNLOAD_DIR/user1/)
         volumes:
           - /home/YOURUSERNAME/.config/streamrip:/config/streamrip:rw
           - /home/YOURUSERNAME/media-server/data/Music:/music:rw

--- a/app.py
+++ b/app.py
@@ -23,6 +23,7 @@ app = Flask(__name__)
 STREAMRIP_CONFIG = os.environ.get('STREAMRIP_CONFIG', '/config/config.toml') 
 DOWNLOAD_DIR = os.environ.get('DOWNLOAD_DIR', '/music') 
 MAX_CONCURRENT_DOWNLOADS = int(os.environ.get('MAX_CONCURRENT_DOWNLOADS', '2')) 
+STREAMRIP_USERS = os.environ.get("STREAMRIP_USERS")
 
 download_queue = queue.Queue()
 active_downloads = {}
@@ -30,6 +31,10 @@ download_history = []
 sse_clients = []
 album_art_cache = {}
 cache_lock = threading.Lock()
+if STREAMRIP_USERS:
+    USERS = [user.strip() for user in STREAMRIP_USERS.split(",") if user.strip()]
+else:
+    USERS = []
          
 class DownloadWorker(threading.Thread):
     def __init__(self):
@@ -46,19 +51,23 @@ class DownloadWorker(threading.Thread):
             url = task['url']
             quality = task.get('quality', 3)
             metadata = task.get('metadata', {})
+            download_dir = task.get("directory", DOWNLOAD_DIR)
+            user = task.get('user')
             
             active_downloads[task_id] = {
                 'status': 'downloading',
                 'url': url,
                 'metadata': metadata,
-                'started': time.time()
+                'started': time.time(),
+                'user': user
             }
             
             broadcast_sse({
                 'type': 'download_started',
                 'id': task_id,
                 'metadata': metadata,
-                'status': 'downloading'
+                'status': 'downloading',
+                'user': user
             })
             
             output_lines = []
@@ -68,7 +77,7 @@ class DownloadWorker(threading.Thread):
                 cmd = ['rip']
                 if os.path.exists(STREAMRIP_CONFIG):
                     cmd.extend(['--config-path', STREAMRIP_CONFIG])
-                cmd.extend(['-f', DOWNLOAD_DIR])
+                cmd.extend(['-f', download_dir])
                 cmd.extend(['-q', str(quality)])
                 cmd.extend(['url', url])
 
@@ -103,7 +112,8 @@ class DownloadWorker(threading.Thread):
                     'id': task_id,
                     'status': 'completed' if process.returncode == 0 else 'failed',
                     'metadata': metadata,
-                    'output': "\n".join(output_lines)
+                    'output': "\n".join(output_lines),
+                    'user': user
 
                 })
                             
@@ -112,7 +122,8 @@ class DownloadWorker(threading.Thread):
                     'type': 'download_error',
                     'id': task_id,
                     'error': str(e),
-                    'output': "\n".join(output_lines) if output_lines else str(e)
+                    'output': "\n".join(output_lines) if output_lines else str(e),
+                    'user': user
                 })
             
             finally:
@@ -170,15 +181,37 @@ for _ in range(MAX_CONCURRENT_DOWNLOADS):
     worker.start()
     workers.append(worker)
 
-@app.route('/')
-def index():
-    return render_template('index.html')
+def create_user_routes(app, users):
+    for user in users:
+        route_path = f"/{user}/"
+
+        def user_route(user=user):
+            return render_template("index.html", user=user)
+
+        # Use a unique endpoint name for each route
+        endpoint_name = f"user_{user}"
+        app.route(route_path, endpoint=endpoint_name)(user_route)
+
+
+if USERS:
+
+    @app.route("/")
+    def user_list_page():
+        return render_template("users.html", users=USERS)
+
+    create_user_routes(app, USERS)
+else:
+    
+    @app.route('/')
+    def index():
+        return render_template('index.html', user=None)
 
 @app.route('/api/download', methods=['POST'])
 def start_download():
     data = request.json
     url = data.get('url')
     quality = data.get('quality', 3)
+    user = data.get("user")
     
     if not url:
         return jsonify({'error': 'URL is required'}), 400
@@ -189,6 +222,19 @@ def start_download():
     if not any(service in url.lower() for service in valid_services):
         return jsonify({'error': 'Unsupported service URL'}), 400
     
+    if USERS:
+        if not user or user not in USERS:
+            return jsonify({'error': 'Unauthorized or missing user'}), 403
+        directory = os.path.join(DOWNLOAD_DIR, user)
+    else:
+        directory = DOWNLOAD_DIR
+
+    if not os.path.exists(directory):
+        try:
+            os.makedirs(directory, exist_ok=True)
+        except Exception as e:
+            return jsonify({"error": f"Failed to create directory: {e}"}), 500
+    
     metadata = extract_metadata_from_url(url)
     
     task_id = f"dl_{int(time.time() * 1000)}"
@@ -196,7 +242,9 @@ def start_download():
         'id': task_id,
         'url': url,
         'quality': quality,
-        'metadata': metadata 
+        'metadata': metadata,
+        "directory": directory,
+        "user": user,
     }
     
     download_queue.put(task)
@@ -206,9 +254,18 @@ def start_download():
 
 @app.route('/api/status')
 def get_all_status():
+    user = request.args.get('user')
+    
+    filtered_active = active_downloads
+    filtered_history = download_history[-20:]
+    
+    if USERS and user:
+        filtered_active = {k: v for k, v in active_downloads.items() if v.get('user') == user}
+        filtered_history = [h for h in download_history[-20:] if h.get('user') == user]
+    
     return jsonify({
-        'active': active_downloads,
-        'history': download_history[-20:],
+        'active': filtered_active,
+        'history': filtered_history,
         'queue_size': download_queue.qsize()
     })
 
@@ -540,13 +597,21 @@ def get_album_art():
 
 @app.route('/api/browse')
 def browse_downloads():
+    user = request.args.get('user')
+    if USERS:
+        if not user or user not in USERS:
+            return jsonify({'error': 'Unauthorized or missing user'}), 403
+        search_dir = os.path.join(DOWNLOAD_DIR, user)
+    else:
+        search_dir = DOWNLOAD_DIR
+
     try:
         files = []
-        for root, dirs, filenames in os.walk(DOWNLOAD_DIR):
+        for root, dirs, filenames in os.walk(search_dir):
             for filename in filenames:
                 if filename.endswith(('.mp3', '.flac', '.m4a', '.opus')):
                     filepath = os.path.join(root, filename)
-                    rel_path = os.path.relpath(filepath, DOWNLOAD_DIR)
+                    rel_path = os.path.relpath(filepath, search_dir)
                     files.append({
                         'name': rel_path,
                         'size': os.path.getsize(filepath),
@@ -802,6 +867,7 @@ def download_from_url():
     data = request.json
     url = data.get('url')
     quality = data.get('quality', 3)
+    user = data.get("user")
     
     title = data.get('title')
     artist = data.get('artist')
@@ -810,6 +876,19 @@ def download_from_url():
     
     if not url:
         return jsonify({'error': 'URL required'}), 400
+    
+    if USERS:
+        if not user or user not in USERS:
+            return jsonify({'error': 'Unauthorized or missing user'}), 403
+        directory = os.path.join(DOWNLOAD_DIR, user)
+    else:
+        directory = DOWNLOAD_DIR
+
+    if not os.path.exists(directory):
+        try:
+            os.makedirs(directory, exist_ok=True)
+        except Exception as e:
+            return jsonify({"error": f"Failed to create directory: {e}"}), 500
     
     if title and artist and service:
         metadata = {
@@ -826,7 +905,9 @@ def download_from_url():
         'id': task_id,
         'url': url,
         'quality': quality,
-        'metadata': metadata
+        'metadata': metadata,
+        "directory": directory,
+        "user": user,
     }
     
     download_queue.put(task)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -838,3 +838,39 @@ button:disabled {
         padding: 10px;
     }
 }
+
+/* User List Styles */
+.user-list {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    padding: 25px;
+    margin-bottom: 20px;
+    border-radius: 4px;
+}
+
+.user-list ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.user-list li {
+    margin-bottom: 15px;
+}
+
+.user-list a {
+    display: inline-block;
+    padding: 10px 15px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    text-decoration: none;
+    color: var(--text-primary);
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 14px;
+    transition: background 0.2s, border-color 0.2s;
+}
+
+.user-list a:hover {
+    background: var(--bg-tertiary);
+    border-color: var(--accent);
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -33,6 +33,12 @@ function initializeSSE() {
 }
 
 function handleSSEMessage(data) {
+    const user = getCurrentUser();
+    
+    // Filter by user if user filtering is enabled
+    if (user && data.user && data.user !== user) {
+        return;
+    }
     
     switch(data.type) {
         case 'download_started':
@@ -261,12 +267,20 @@ function switchTab(tab, element) {
 async function startDownload() {
     const url = document.getElementById('urlInput').value.trim();
     const quality = document.getElementById('qualitySelect').value;
+    const user = getCurrentUser();
     
     if (!url) {
         alert('Please enter a URL');
         return;
     }
     
+    // Prepare payload
+    const payload = { url, quality: parseInt(quality) };
+
+    if (user) {
+        payload['user'] = user;
+    }
+
     const btn = document.getElementById('downloadBtn');
     btn.disabled = true;
     
@@ -274,7 +288,7 @@ async function startDownload() {
         const response = await fetch('/api/download', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ url, quality: parseInt(quality) })
+            body: JSON.stringify(payload)
         });
         
         const data = await response.json();
@@ -325,8 +339,11 @@ async function saveConfig() {
 }
 
 async function loadFiles() {
+    const user = getCurrentUser();
+    
     try {
-        const response = await fetch('/api/browse');
+        const url = user ? `/api/browse?user=${encodeURIComponent(user)}` : '/api/browse';
+        const response = await fetch(url);
         const files = await response.json();
         
         const container = document.getElementById('fileList');
@@ -481,6 +498,7 @@ function displayCurrentPage() {
     updatePaginationControls();
     loadAlbumArtForVisibleItems();
 }
+
 function updatePaginationControls() {
     const totalPages = Math.ceil(totalResults / itemsPerPage);
     document.getElementById('pageInfo').textContent = `Page ${currentPage} of ${totalPages}`;
@@ -601,8 +619,10 @@ async function loadAlbumArtForVisibleItems() {
         }
     }
 }
+
 async function downloadFromUrl(url) {
     const quality = document.getElementById('qualitySelect').value;
+    const user = getCurrentUser();
     
     const searchResults = document.querySelectorAll('.search-result-item');
     let metadata = {};
@@ -626,15 +646,21 @@ async function downloadFromUrl(url) {
     
     switchTab('active');
     
+    const payload = {
+        url: url,
+        quality: parseInt(quality),
+        ...metadata
+    };
+
+    if (user) {
+        payload['user'] = user;
+    }
+    
     try {
         const response = await fetch('/api/download-from-url', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ 
-                url: url,
-                quality: parseInt(quality),
-                ...metadata
-            })
+            body: JSON.stringify(payload)
         });
         
         const data = await response.json();
@@ -648,6 +674,10 @@ async function downloadFromUrl(url) {
     }
 }
 
+function getCurrentUser() {
+    const pathParts = window.location.pathname.split('/').filter(Boolean);
+    return pathParts.length > 0 ? pathParts[0] : null;
+}
 
 window.addEventListener('load', () => {
     initializeSSE();

--- a/templates/users.html
+++ b/templates/users.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Streamrip Web</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+	<link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>STREAMRIP WEB</h1>
+            <p class="subtitle">WEB GUI FOR STREAMRIP</p>
+        </div>
+        
+        <!-- User Section-->
+        <div class="section">
+            <div class="section-header">
+                <h2>Users</h2>
+                <div class="divider"></div>
+            </div>
+            {% if users %}
+                <div class="user-list">
+                    <ul>
+                        {% for user in users %}
+                            <li><a href="/{{ user }}/">{{ user }}</a></li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            {% else %}
+                <p>No users available.</p>
+            {% endif %}
+        </div>
+        
+    </div>
+</body>
+</html>


### PR DESCRIPTION
feat: Add multi-user support with environment variable STREAMRIP_USERS
- Introduce STREAMRIP_USERS environment variable to define allowed users
  (comma-separated)
- Implement user-specific download directories (e.g., /music/username/)
- Add user validation to /api/download and /api/download-from-url
  endpoints
- Update browse_downloads to scope file listing to user-specific
  directories
- Enhance status tracking to include user information and support
  filtering
- Create user selection page at / when STREAMRIP_USERS is configured
- Update frontend to extract user from URL path and pass to API
  endpoints
- Add styling for user list page
- Update README.md to document new environment variable